### PR TITLE
Get host by name to enable UDP link to sim

### DIFF
--- a/client/skydio/comms/udp_link.py
+++ b/client/skydio/comms/udp_link.py
@@ -33,7 +33,7 @@ class UDPLink(object):
         self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.server_socket.settimeout(0.05)
         self.server_socket.bind(('', local_port))
-        self.remote_address = remote_address
+        self.remote_address = socket.gethostbyname(remote_address[0]), remote_address[1]
 
         # Prep a reuseable rpc
         self.request = custom_comms_pb2.CustomRpcRequest()


### PR DESCRIPTION
Given a base url for a simulator such as `https://sim.skydio.com`, the current code will report `"dropping packet from unknown address https://sim.skydio.com. X expected"` where X is the actual ipv4 address of the simulator.

This patch gets the ip address of the host from the given name (`simX-Y...` in the example) and uses it for the `remote_address`.  I tested this patch using Python3 with both a simulator and with a live vehicle.